### PR TITLE
Use new name for the ec2_facts module

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
     - codedeploy
 
 - name: "Get Instance Metadata | ec2"
-  action: ec2_facts
+  action: ec2_metadata_facts
   tags:
     - codedeploy
 


### PR DESCRIPTION
Fixes this deprecation warning and allows the module to work with Ansible 2.7

> [DEPRECATION WARNING]: The 'ec2_facts' module is being renamed 'ec2_metadata_facts'. This feature will be removed in version 2.7.